### PR TITLE
Added loop option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# TimedEvent
+# timedEvent
 *version:1.1*
 
-TimedEvent is a jQuery  plugin that displays a countdown timer then triggers a custom event once the timer reaches 0. This event can also be triggered on a remote object rather than the timer.
+timedEvent is a jQuery  plugin that displays a countdown timer then triggers a custom event once the timer reaches 0. This event can also be triggered on a remote object rather than the timer.
 
 ## Options and Attributes
 By default the plugin will look for explicit options passed in via javascript instantiation. If nothing is passed then the plugin will look for on element declaration. Those available declarations are:
@@ -58,7 +58,7 @@ Default: false
 
 ```
 <span class="countDownDefault"></span>
-$('.countDownDefault').TimedEvent().on("te.finish",function(){
+$('.countDownDefault').timedEvent().on("te.finish",function(){
    // make magic happen
 });
 ```
@@ -67,7 +67,7 @@ $('.countDownDefault').TimedEvent().on("te.finish",function(){
 
  ```
  <span class="countDown" data-emit-event="my.refresh" data-loop></span>
- $('.countDown').TimedEvent().on("kjc.priceRefresh",function(){
+ $('.countDown').timedEvent().on("kjc.priceRefresh",function(){
     // make magic happen
 });
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # TimedEvent
-*version:1*
+*version:1.1*
 
 TimedEvent is a jQuery  plugin that displays a countdown timer then triggers a custom event once the timer reaches 0. This event can also be triggered on a remote object rather than the timer.
 
@@ -41,6 +41,17 @@ or
 The time period between events being triggered.
 Default: 30seconds
 
+Whether to loop the countdown recursively or not.
+To set loop to true, you can use `data-loop=true`, `data-loop="true"` or just `data-loop`.
+To set to false, do `data-loop=false`, `data-loop="false"` or just omit the `data-loop` attribute altogether.
+Or use the object property on JS initialisation.
+```
+{
+    loop: true
+}
+```
+Default: false
+
 ## Example usage
 
 **Using default event being triggered from timer element**
@@ -52,10 +63,10 @@ $('.countDownDefault').TimedEvent().on("te.finish",function(){
 });
 ```
 
-**Listening for a custom event on the timer element**
+**Listening for a custom event on the timer element and looping the timer recursively**
 
  ```
- <span class="countDown" data-emit-event="my.refresh"></span>
+ <span class="countDown" data-emit-event="my.refresh" data-loop></span>
  $('.countDown').TimedEvent().on("kjc.priceRefresh",function(){
     // make magic happen
 });

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # timedEvent
-*version:1.1*
+*version:1.2*
 
 timedEvent is a jQuery  plugin that displays a countdown timer then triggers a custom event once the timer reaches 0. This event can also be triggered on a remote object rather than the timer.
 

--- a/example.html
+++ b/example.html
@@ -2,19 +2,19 @@
 <html>
 <head>
     <title>Examples</title>
-    <script src="//code.jquery.com/jquery-1.11.3.min.js"></script>
+    <script src="http://code.jquery.com/jquery-1.11.3.min.js"></script>
     <script src="src/jquery.plugin.timedEvent.js"></script>
 
     <script>
 
         $(function(){
             // using custom event name being triggered from time
-            $('.countDown').TimedEvent().on("my.refresh",function(){
+            $('.countDown').timedEvent().on("my.refresh",function(){
                 $('#displayFeedback').html("<p>kjc.priceRefresh event emitted: " + new Date().toLocaleTimeString()+"</p>")
             });
 
             // using default event being triggered from time
-            $('.countDownDefault').TimedEvent().on("te.finish",function(){
+            $('.countDownDefault').timedEvent().on("te.finish",function(){
                 $('#displayDefaultFeedback').html("<p>cd.finish event emitted: " + new Date().toLocaleTimeString()+"</p>")
             });
 
@@ -27,20 +27,21 @@
 </head>
 <body>
 
+<h1></h1>
 
-<h1>Custom event</h1>
-<span class="countDown" data-emit-event="my.refresh" data-emit-time="10"></span>
+<h2>Custom event <span style="font-size:0.6em;">(with loop)</span></h2>
+<span class="countDown" data-emit-event="my.refresh" data-emit-time="10" data-loop ></span>
 <div id="displayFeedback"></div>
 
 <hr>
 
-<h1>Default event</h1>
+<h2>Default event <span style="font-size:0.6em;">(without loop)</span></h2>
 <span class="countDownDefault"></span>
 <div id="displayDefaultFeedback"></div>
 
 <hr>
 
-<h1>Default event triggered on custom target</h1>
+<h2>Default event triggered on custom target</h2>
 <!-- the timer, somewhere else on the page -->
 <span class="countDownDefault" data-emit-target="#displayDefaultTarget"></span>
 <!-- the target element listening for what ever event is triggered, somewhere on the page -->

--- a/src/jquery.plugin.timedEvent.js
+++ b/src/jquery.plugin.timedEvent.js
@@ -58,7 +58,14 @@
             opts.emitTime = opts.emitTime - 1;
 
             remainingTime = (opts.emitTime.toString().length == 1)? "0"+ opts.emitTime : opts.emitTime;
-            base.$el.html("00:" + remainingTime);
+
+            var mins = Math.floor(remainingTime / 60)
+              , secs = remainingTime - (mins * 60);
+
+            mins = mins < 10 ? "0"+mins : mins;
+            secs = secs < 10 ? "0"+secs : secs;
+
+            base.$el.html(mins+":" + secs);
 
             if( !opts.emitTime ){
 

--- a/src/jquery.plugin.timedEvent.js
+++ b/src/jquery.plugin.timedEvent.js
@@ -11,7 +11,7 @@
  */
 
 ;(function ( $ ) {
-    var pluginName = "TimedEvent";
+    var pluginName = "timedEvent";
 
     var vstimer = function ( el, options ) {
 
@@ -68,6 +68,8 @@
                     base.$emitTarget.trigger(opts.emitEvent);
                 }
                 base.options.emitTime = base.startCount;
+
+              if( !opts.loop ) clearInterval( base.interval );
             }
         };
 
@@ -76,12 +78,13 @@
 
     /**
      * Default options
-     * @type {{emitEvent: string, emitTarget: boolean, time: number}}
+     * @type {{emitEvent: string, emitTarget: boolean, time: number, loop: boolean}}
      */
     vstimer.defaultOptions = {
         emitEvent: "te.finish",
         emitTarget: false,
-        emitTime: 30
+        emitTime: 30,
+        loop: false
     };
 
     /**
@@ -91,14 +94,23 @@
      * @constructor
      */
     $.fn[pluginName] = function (  options ) {
+
+        // ensures 'options' is an object literal (and not an array either)
+        options = (typeof options !== "object" || $.isArray(options) ) ? {} : options;
+
         return this.each(function () {
 
-            var $this = $(this)
-            , options = options || {};
+            var $this = $(this);
 
             // take preference for object, otherwise fallback to data attribute
             options.emitTarget = options.emitTarget || $this.data("emitTarget");
 
+            /**
+             * To set loop to true, you can use `data-loop=true`, `data-loop="true"` or just `data-loop`.
+             * To set to false, do `data-loop=false`, `data-loop="false"` or just omit the `data-loop` attribute altogether.
+             */
+            var loop = $this.data("loop") || false;
+            options.loop = options.loop || (loop === "" ? true : loop);
 
             options.emitEvent = options.emitEvent || $this.data("emitEvent");
             options.emitTime = options.emitTime || $this.data("emitTime");

--- a/src/jquery.plugin.timedEvent.js
+++ b/src/jquery.plugin.timedEvent.js
@@ -13,7 +13,7 @@
 ;(function ( $ ) {
     var pluginName = "timedEvent";
 
-    var vstimer = function ( el, options ) {
+    var vstimer = function ( el, options, funcName ) {
 
         var base = this;
 
@@ -44,8 +44,18 @@
             }
 
             // start the ticker
-            base.interval =  setInterval(base._processInterval, 1000);
+            base.play();
         };
+
+        base.pause = function() {
+          console.log( "pause the timer" );
+          clearInterval(base.interval);
+        }
+
+        base.play = function() {
+          console.log( "play the timer" );
+          base.interval =  setInterval(base._processInterval, 1000);
+        }
 
         /**
          * @description interval
@@ -80,7 +90,7 @@
             }
         };
 
-        base.init();
+        if(!funcName) base.init();
     };
 
     /**
@@ -96,33 +106,53 @@
 
     /**
      * Creates the plugin instance on
-     * @param options
+     * @param _funcName (string/object) optional - The name of the function you wish to call. If object is passed instead, will use this as the 'options' object and default to 'init' function.
+     * @param options (object) optional - Will use plugin defaults if none passed.
      * @returns {*}
      * @constructor
      */
-    $.fn[pluginName] = function (  options ) {
+    $.fn[pluginName] = function ( _funcName, options ) {
+
+        var funcName;
+
+        // if first arg is not a function name (string), assume it's a config object
+        if(typeof _funcName === "object" )      options = _funcName;
+        else if(typeof _funcName === "string" ) funcName = _funcName;
 
         // ensures 'options' is an object literal (and not an array either)
         options = (typeof options !== "object" || $.isArray(options) ) ? {} : options;
 
         return this.each(function () {
 
-            var $this = $(this);
+            var $this = $(this)
+              , instance;
 
-            // take preference for object, otherwise fallback to data attribute
-            options.emitTarget = options.emitTarget || $this.data("emitTarget");
+            if( !funcName ) {
+              // take preference for object, otherwise fallback to data attribute
+              options.emitTarget = options.emitTarget || $this.data("emitTarget");
 
-            /**
-             * To set loop to true, you can use `data-loop=true`, `data-loop="true"` or just `data-loop`.
-             * To set to false, do `data-loop=false`, `data-loop="false"` or just omit the `data-loop` attribute altogether.
-             */
-            var loop = $this.data("loop");
-            options.loop = options.loop || (loop === "" ? true : (loop || false));
+              /**
+               * To set loop to true, you can use `data-loop=true`, `data-loop="true"` or just `data-loop`.
+               * To set to false, do `data-loop=false`, `data-loop="false"` or just omit the `data-loop` attribute altogether.
+               */
+              var loop = $this.data("loop");
+              options.loop = options.loop || (loop === "" ? true : (loop || false));
 
-            options.emitEvent = options.emitEvent || $this.data("emitEvent");
-            options.emitTime = options.emitTime || $this.data("emitTime");
+              options.emitEvent = options.emitEvent || $this.data("emitEvent");
+              options.emitTime = options.emitTime || $this.data("emitTime");
 
-            ( new vstimer(this,  options));
+              instance = new vstimer(this,  options, funcName);
+              $this.data("instance", instance);
+            } else {
+              instance = $this.data("instance");
+
+              if(!instance) return;
+
+              switch(funcName) {
+                case "pause": instance.pause(); break;
+                case "play": instance.play(); break;
+              }
+            }
         });
     };
 

--- a/src/jquery.plugin.timedEvent.js
+++ b/src/jquery.plugin.timedEvent.js
@@ -109,8 +109,8 @@
              * To set loop to true, you can use `data-loop=true`, `data-loop="true"` or just `data-loop`.
              * To set to false, do `data-loop=false`, `data-loop="false"` or just omit the `data-loop` attribute altogether.
              */
-            var loop = $this.data("loop") || false;
-            options.loop = options.loop || (loop === "" ? true : loop);
+            var loop = $this.data("loop");
+            options.loop = options.loop || (loop === "" ? true : (loop || false));
 
             options.emitEvent = options.emitEvent || $this.data("emitEvent");
             options.emitTime = options.emitTime || $this.data("emitTime");


### PR DESCRIPTION
Added 'loop' option, which gives you the option to recursively loop the timer or stop it after 1 cycle.
Also change the plugin to use lowercase 't' - not sure if you'll agree with that? I usually use camel case for these things.
Also, the options weren't coming through when passed in via JS config, because the 'each' loop was overriding the value of 'options' in a local variable with each iteration. So fixed that too.
Added 'http' to the jQuery reference in the example html, just so you can run it without a server.
Added support for minutes. Previously the display would do this "00:110". Now that would be "01:50".
Also added "play" and "pause" functions.
